### PR TITLE
Add "fee_amount" to SEPA credit transfer definition

### DIFF
--- a/schema/v1.0/sepa_credit_transfer.json
+++ b/schema/v1.0/sepa_credit_transfer.json
@@ -31,6 +31,10 @@
       "$ref"     : "./base_types/base_types.json#definitions/currency",
       "readOnly" : true
     },
+    "fee_amount" : {
+      "$ref"     : "./base_types/base_types.json#definitions/amount",
+      "readOnly" : true
+    },
     "remote_name" : {
       "description" : "Receiving account holder name",
       "type"        : "string",


### PR DESCRIPTION
`fee_amount` is defined for various use cases so its default value for regular FidorApi will be 0 for now. This should not break the existing FidorApi clients as long as they don't use strict JSON validation when parsing the output.