### PR TITLE
`creditor_identity_id` instead of `creditor_identifier`

### DIFF
--- a/schema/v1.0/customer.json
+++ b/schema/v1.0/customer.json
@@ -112,11 +112,6 @@
       "format"      : "date-time",
       "readOnly"    : true
     },
-    "creditor_identifier" : {
-      "description" : "Creditor Identifier ID set if the customer wants to create direct debits.",
-      "type"        : "string",
-      "readOnly"    : true
-    },
     "is_verified" : {
       "description" : "Indicates whether KYC has been performed.",
       "type"        : "boolean",

--- a/schema/v1.0/sepa_direct_debit.json
+++ b/schema/v1.0/sepa_direct_debit.json
@@ -21,8 +21,8 @@
       "description" : "The sepa mandate used by the debit",
       "type"        : "string"
     },
-    "creditor_identifier" : {
-      "description" : "Creditor Identifier",
+    "creditor_identity_id" : {
+      "description" : "Unique identifier of the creditor sepa mandate has been created with",
       "type"        : "string",
       "readOnly"    : true
     },

--- a/schema/v1.0/transaction.json
+++ b/schema/v1.0/transaction.json
@@ -44,6 +44,7 @@
         "unknown"
       ],
       "type" : "string",
+      "maxLength"   : 255,
       "readOnly" : true
     },
     "transaction_type_details" : {


### PR DESCRIPTION
Since `creditor_identifier` was an initial draft on providing the multiple UCI functionality, it had to be changed to `creditor_identity_id` according to the current implementation
