### PR TITLE
Added fee base type and used it in sepa_credit_transfer's fee_amount.

### DIFF
--- a/schema/v1.0/base_types/base_types.json
+++ b/schema/v1.0/base_types/base_types.json
@@ -127,6 +127,11 @@
       "description"      : "The transferred amount in account currency, in minor units, e.g. 1EUR is represented as 100. Must be greater than 0 e.g. at least one cent in EUR",
       "type"             : "integer",
       "minimum"          : 1
+    },
+    "fee" : {
+      "description"      : "A fee amount in account currency, in minor units, e.g. 1EUR is represented as 100.",
+      "type"             : "integer",
+      "minimum"          : 0
     }
   }
 }

--- a/schema/v1.0/sepa_credit_transfer.json
+++ b/schema/v1.0/sepa_credit_transfer.json
@@ -32,9 +32,8 @@
       "readOnly" : true
     },
     "fee_amount" : {
-      "$ref"     : "./base_types/base_types.json#definitions/amount",
-      "readOnly" : true,
-      "minimum"  : 0
+      "$ref"     : "./base_types/base_types.json#definitions/fee",
+      "readOnly" : true
     },
     "remote_name" : {
       "description" : "Receiving account holder name",


### PR DESCRIPTION
`amount` type couldn't be used, because it restricts the number with `> 0`, but fees can be `= 0`. :+1: 

cc @igorkosta 