### PR TITLE
Updated transaction_type - Patched schema for CircularReferenceException

### DIFF
--- a/schema/v1.0/transaction.json
+++ b/schema/v1.0/transaction.json
@@ -12,40 +12,7 @@
       "readOnly" : true
     },
     "transaction_type" : {
-      "description" : "Type of the transaction",
-      "enum"        : [
-        "bonus",
-        "credit_interest",
-        "creditcard_annual_fee",
-        "creditcard_atm_fee",
-        "creditcard_foreign_exchange_fee",
-        "creditcard_notification_fee",
-        "creditcard_order_cancellation",
-        "creditcard_order_fee",
-        "creditcard_order_withdrawal_fee",
-        "creditcard_payin",
-        "creditcard_payout",
-        "creditcard_preauth",
-        "creditcard_release",
-        "debit_interest",
-        "emoney_payin",
-        "fee",
-        "fidor_payin",
-        "fidor_payout",
-        "gmt_fee",
-        "gmt_refund",
-        "gmt_payout",
-        "payout",
-        "prepaid_mobile_topup",
-        "sepa_authorization",
-        "sepa_b2b_direct_debit",
-        "sepa_core_direct_debit",
-        "sepa_payin",
-        "unknown"
-      ],
-      "type" : "string",
-      "maxLength"   : 255,
-      "readOnly" : true
+      "$ref" : "#definitions/transaction_type"
     },
     "transaction_type_details" : {
       "description" : "Details specific to this transaction type are collected here.",
@@ -124,6 +91,44 @@
       "$ref" : "./base_types/base_types.json#definitions/updated_at"
     }
   },
+  "definitions" :{
+    "transaction_type": {
+      "description" : "Type of the transaction",
+      "enum"        : [
+        "bonus",
+        "credit_interest",
+        "creditcard_annual_fee",
+        "creditcard_atm_fee",
+        "creditcard_foreign_exchange_fee",
+        "creditcard_notification_fee",
+        "creditcard_order_cancellation",
+        "creditcard_order_fee",
+        "creditcard_order_withdrawal_fee",
+        "creditcard_payin",
+        "creditcard_payout",
+        "creditcard_preauth",
+        "creditcard_release",
+        "debit_interest",
+        "emoney_payin",
+        "fee",
+        "fidor_payin",
+        "fidor_payout",
+        "gmt_fee",
+        "gmt_refund",
+        "gmt_payout",
+        "payout",
+        "prepaid_mobile_topup",
+        "sepa_authorization",
+        "sepa_b2b_direct_debit",
+        "sepa_core_direct_debit",
+        "sepa_payin",
+        "unknown"
+      ],
+      "type" : "string",
+      "maxLength"   : 255,
+      "readOnly" : true
+    }
+  },
   "links" : [
     {
       "rel"  : "self",
@@ -169,7 +174,7 @@
           "type"   : "string"
         },
         "filter[transaction_types]" : {
-          "$ref"  : "./base_types/base_types.json#definitions/transaction_type",
+          "$ref"  : "#definitions/transaction_type",
           "title" : "By transaction types"
         },
         "page" : {


### PR DESCRIPTION
```
.rvm/gems/ruby-1.9.3-p448@banking/bundler/gems/fidor_schema-9bdbec3679fd/schema/v1.0/transaction.json $ref: ./base_types/base_types.json#definitions/transaction_type refers to itself:
 ./base_types/base_types.json#definitions/transaction_type (SchemaTools::CircularReferenceException)
./features/step_definitions/fidor_api/json_schema_steps.rb:39:in `/^the response is valid according to the "(.+)" fidor schema$/'
features/fidor_api/v1/transactions.feature:38:in `And the response is valid according to the "transaction" fidor schema'
Failing Scenarios:
cucumber features/fidor_api/v1/transactions.feature:35 # Scenario: GET "/transactions/:id" with valid id
```

@igorkosta @schorsch 