### PR TITLE
No `cvc_code` anymore - just `cvc` everywhere

### DIFF
--- a/lib/fidor_schema_version.rb
+++ b/lib/fidor_schema_version.rb
@@ -1,5 +1,5 @@
 module Fidor
   class Schema
-    VERSION = '0.10.2'
+    VERSION = '0.10.3'
   end
 end

--- a/schema/v1.0/card.json
+++ b/schema/v1.0/card.json
@@ -54,7 +54,7 @@
       "type"        : "string",
       "pattern"     : "^[0-9]{14,16}$"
     },
-    "cvc_code" : {
+    "cvc" : {
       "description" : "Card's cvc code",
       "type"        : "string",
       "pattern"     : "^[0-9]{3}$"
@@ -175,6 +175,13 @@
       "method"      : "GET",
       "rel"         : "pan",
       "title"       : "Primary Account Number"
+    },
+    {
+      "description" : "Card Verification Code",
+      "href"        : "cards/{id}/cvc",
+      "method"      : "GET",
+      "rel"         : "cvc",
+      "title"       : "Card Verification Value Code"
     },
     {
       "description" : "Lock a card",


### PR DESCRIPTION
Unified the use of `cvc` across different `cards` related actions. Bumped up the gem version.